### PR TITLE
Update ghostwriter/coding-standard to version dev-main#2defba4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -638,12 +638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "1ebe0356ba4e31c74b5da0a5635bcf4e127dfa9d"
+                "reference": "2defba4c2ec6d1f49126d4301dee269157d3b410"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/1ebe0356ba4e31c74b5da0a5635bcf4e127dfa9d",
-                "reference": "1ebe0356ba4e31c74b5da0a5635bcf4e127dfa9d",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2defba4c2ec6d1f49126d4301dee269157d3b410",
+                "reference": "2defba4c2ec6d1f49126d4301dee269157d3b410",
                 "shasum": ""
             },
             "require": {
@@ -682,7 +682,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.2",
-                "phpunit/phpunit": "^12.4.3",
+                "phpunit/phpunit": "^12.4.4",
                 "symfony/var-dumper": "^7.3.5"
             },
             "default-branch": true,
@@ -787,7 +787,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-20T19:24:51+00:00"
+            "time": "2025-11-21T07:45:01+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#1ebe035` to `dev-main#2defba4`.

This pull request changes the following file(s): 

- Update `composer.lock`