### PR TITLE
Update boundwize/structarmed to version 0.6.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.15",
+        "boundwize/structarmed": "^0.6.16",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3781ed47b6976b562156418f1a63b2f7",
+    "content-hash": "8dfcc07b77fadbfaafb75a9f8c3ac93a",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.15",
+            "version": "0.6.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "1c9f1eac7058af6117b4581fbecaff001fb38e97"
+                "reference": "8df4838a8266ed13867f9647ac52d98fc5a307d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/1c9f1eac7058af6117b4581fbecaff001fb38e97",
-                "reference": "1c9f1eac7058af6117b4581fbecaff001fb38e97",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/8df4838a8266ed13867f9647ac52d98fc5a307d4",
+                "reference": "8df4838a8266ed13867f9647ac52d98fc5a307d4",
                 "shasum": ""
             },
             "require": {
@@ -67,7 +67,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.15"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.16"
             },
             "funding": [
                 {
@@ -75,7 +75,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-20T13:36:47+00:00"
+            "time": "2026-05-21T05:21:20+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -144,16 +144,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "6439cb7c20121d26b48e7798f9ac69fc695ac8ff"
+                "reference": "f40d7d3a923f6645a95b736fdeb625399bc8b0bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/6439cb7c20121d26b48e7798f9ac69fc695ac8ff",
-                "reference": "6439cb7c20121d26b48e7798f9ac69fc695ac8ff",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f40d7d3a923f6645a95b736fdeb625399bc8b0bb",
+                "reference": "f40d7d3a923f6645a95b736fdeb625399bc8b0bb",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.15",
+                "boundwize/structarmed": "^0.6.16",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -264,7 +264,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-20T17:12:56+00:00"
+            "time": "2026-05-21T06:37:46+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.15` to `0.6.16`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`